### PR TITLE
Fix: Word find traverses comments inside link content

### DIFF
--- a/tests/index.htm
+++ b/tests/index.htm
@@ -169,6 +169,13 @@
                 <a href="/" download target="_blank"><span class="visually-hidden" style="opacity: .25;"></span></a>
                 <a href="/" download target="_blank"></a>
             </li>
+            <li>
+              This link should still have comments surrounding the span: Handling <a href="/" download target="_blank">
+                <!-- This is a start of an existing comment -->
+                comments
+                <!-- This is the end of an existing comment -->
+              </a> inside link content.
+            </li>
             </ul>
         </div>
         <div>


### PR DESCRIPTION
While reviewing this on our platform, we ran into an issue where comments surrounding the text inside of a link due to having Drupal debugging on, and a twig render of the text, resulted in the text not being surrounded by a span. (Just this JS file, not the Drupal module as we wanted this to be driven by our component library)

After fixing this, I found that comments were acting strangely where you'd get the following markup:

```html
<!---->
<a href="...">
  Text above span
  <span...></span>
</a>
The text that was inside of the comment.
```

This fix does two things:

- Allows comments to be bypassed to get real text
- Tracks comments found so that it can re-introduce them properly as new nodes, keeping the structure/order of the comments in tact.

Example:
```html
<a href="...">
  <!-- BEGIN: twigfile.twig -->
  Text of the link
  <!-- END: twigfile.twig -->
</a>
```

to

```html
<a href="...">
  <!-- BEGIN: twigfile.twig -->
  Text of the 
  <span...>
    link <icon here>
  </span>
  <!-- END: twigfile.twig -->
</a>
```