### PR TITLE
Fix spacing between link text and span

### DIFF
--- a/js/linkpurpose.js
+++ b/js/linkpurpose.js
@@ -422,7 +422,7 @@ class LinkPurpose {
                       })
                     }
                     lastTextNode.textContent = lastText.substring(0, lastText.length - lastWord[0].length)
-                    lastTextNode.parentNode.append(' ',breakPreventer)
+                    lastTextNode.parentNode.append('\u00A0', breakPreventer)
                     if (trailingWhitespace.length > 0) {
                       // Move whitespace out of link.
                       trailingWhitespace.forEach(space => {

--- a/js/linkpurpose.js
+++ b/js/linkpurpose.js
@@ -348,9 +348,11 @@ class LinkPurpose {
       marks.forEach((mark) => {
         mark.hits.forEach((hit, i) => {
           // Don't append redundant screen reader text.
+          // If no message exists, don't show it either.
           let showText = !(LinkPurpose.options.purposes[hit.type].redundantStrings &&
             mark.link.textContent.length > 0 &&
-            mark.link.textContent.match(LinkPurpose.options.purposes[hit.type].redundantStrings));
+            mark.link.textContent.match(LinkPurpose.options.purposes[hit.type].redundantStrings)) &&
+            LinkPurpose.options.purposes[hit.type].message
 
           if (i === 0) {
             let spanTarget = mark.link


### PR DESCRIPTION
In my tests, the space that once was separating the last word and the previous word to it was gone, making the visual output look as if they were not separated.  This adds an encoded space that does not seem to be read by a screen reader, yet still visually makes the text look spaced out.

Before:
<img width="462" alt="before" src="https://github.com/itmaybejj/linkpurpose/assets/128765777/c4fc753e-61e6-4e06-84a6-0f239041f357">

After:
<img width="446" alt="after" src="https://github.com/itmaybejj/linkpurpose/assets/128765777/dd784c08-cbde-4e66-98a4-001c9924881b">

Another thing snuck into this was to not display the message if the message itself is blank.  Before, it was creating a message of `()`.  Our use case was adding a new purpose for a chevron which did not need a message.