### PR TITLE
fix(spacing): add optional flex spacing fix

### DIFF
--- a/css/linkpurpose.css
+++ b/css/linkpurpose.css
@@ -47,3 +47,7 @@
 .link-purpose-text:empty {
     display: none;
 }
+
+.link-purpose-space {
+  white-space: pre-wrap;
+}

--- a/js/linkpurpose.js
+++ b/js/linkpurpose.js
@@ -52,6 +52,8 @@ class LinkPurpose {
       // Mask headers when users click out to external links
       noReferrer: false,
 
+      fixFlexSpacing: false,
+
       purposes: {
 
         // These are listed in priority order
@@ -422,7 +424,7 @@ class LinkPurpose {
                       })
                     }
                     lastTextNode.textContent = lastText.substring(0, lastText.length - lastWord[0].length)
-                    lastTextNode.parentNode.append('\u00A0', breakPreventer)
+                    lastTextNode.parentNode.append(' ', breakPreventer)
                     if (trailingWhitespace.length > 0) {
                       // Move whitespace out of link.
                       trailingWhitespace.forEach(space => {
@@ -456,6 +458,17 @@ class LinkPurpose {
                   iconSpan.classList.add(cls)
                 })
               }
+
+              // If we're to fix flex issues with the last space before the
+              // no-break span, we create a new div that handles the space.
+              // Reference: https://stackoverflow.com/questions/39325039/css-flex-box-last-space-removed
+              if (LinkPurpose.options.fixFlexSpacing) {
+                const spaceSpan = document.createElement('span')
+                spaceSpan.classList.add('link-purpose-space')
+                spaceSpan.textContent = ' ';
+                spanTarget.insertAdjacentElement('beforebegin', spaceSpan);
+              }
+
               spanTarget.insertAdjacentElement(LinkPurpose.options.purposes[hit.type].iconPosition, iconSpan);
             } else {
               mark.link.classList.add(LinkPurpose.options.baseLinkClass)


### PR DESCRIPTION
Discussed more in #3, this helps users finding spacing issues while using flex-based links have a pre-wrap span that keeps the space in between the no-break span and the rest of the link.

To use: set `fixFlexSpacing: true` in your options passed to linkpurpose.  Let me know if we either don't want this optional or if a better name exists.

![Screenshot 2024-05-16 at 12 18 24 PM](https://github.com/itmaybejj/linkpurpose/assets/128765777/9a13f7bc-b8cc-4d38-af16-c0a477aa6250)

```html
<a data-link-style="underline-with-icon" data-link-type="with-chevron" class="link link--with-icon external-link link-purpose link-purpose-chevron" href="#">
    This is a link with
    <span class="link-purpose-space"> </span>
    <span class="link-purpose-nobreak">
       chevron
       <span class="link-purpose-icon link-purpose-chevron-icon" aria-hidden="true" title="">
          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
             <!--! Font Awesome Pro 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M278.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-160 160c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L210.7 256 73.4 118.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l160 160z"></path>
          </svg>
       </span>
       <span class="link-purpose-text"></span>
    </span>
</a>
```